### PR TITLE
Reflect on new login method and setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,12 +22,18 @@ Check the Chrome version with:
 google-chrome --version
 ```
 
-For Raspberry Pi, a chromedriver designed for corresponding ARM architecture is needed. <br>
-In Raspbian Buster, replace the chromedriver binary with:
+For Raspberry Pi, a chromedriver designed for corresponding ARM architecture is needed.<br>
+In Raspbian Buster/Bullseye, replace the chromedriver binary in the cloned repo with:
 ```
+sudo apt update
+
+# You will get the latest driver in this step
 sudo apt install chromium-chromedriver
 rm -f ./chromedriver
 ln -s $(realpath /usr/lib/chromium-browser/chromedriver)
+
+# Update your chromium as the driver is locked to chromium version
+sudo apt upgrade chromium-browser
 ```
 
 ## How To Use

--- a/login.py
+++ b/login.py
@@ -2,8 +2,8 @@ from splinter.browser import Browser
 from time import sleep
  
 URL = 'https://securelogin.wlan.cuhk.edu.hk/'
-ACCTNAME = ''
-PASSWORD = '' #remember to change it to your own Onepass password
+ACCTNAME = '' # remember to change it to your CUHK email used for logging in WiFi
+PASSWORD = '' # remember to change it to your own Onepass password
  
 def main():
     #br = Browser('chrome', executable_path='./chromedriver')

--- a/login.py
+++ b/login.py
@@ -1,9 +1,8 @@
 from splinter.browser import Browser
 from time import sleep
  
-URL = 'https://securelogin.net.cuhk.edu.hk/upload/custom/CUPortal/login.html'
-SID = '1155000000'
-CUHKHOST = '@link.cuhk.edu.hk'
+URL = 'https://securelogin.wlan.cuhk.edu.hk/'
+ACCTNAME = ''
 PASSWORD = '' #remember to change it to your own Onepass password
  
 def main():
@@ -11,9 +10,13 @@ def main():
     br = Browser('chrome', executable_path='./chromedriver', headless=True)
     print('opened')
     br.visit(URL)
-    print('visted')
-    sleep(1)
-    br.fill('user', SID+CUHKHOST)
+    print('visited')
+    sleep(5)
+    br.find_by_xpath('//input[@type="checkbox"]').first.click()
+    br.find_by_name('accept').first.click()
+    print('accept terms')
+    sleep(5)
+    br.fill('user', ACCTNAME)
     br.fill('password', PASSWORD)
     br.find_by_name('submit').first.click()
     sleep(3)

--- a/monitor.py
+++ b/monitor.py
@@ -10,8 +10,9 @@ import urllib.error
 import subprocess
 
 PROCNAME = 'chromedriver'
-SLEEP_TIME = 10
- 
+SUCC_SLEEP_TIME = 60 * 60 * 2 # 2 hours
+FAIL_SLEEP_TIME = 10
+
 def kill_chromedriver():
     for proc in psutil.process_iter():
         if proc.name == PROCNAME:
@@ -46,15 +47,18 @@ def start_wifi():
     print('# restarted internet connection')
  
 def main():
+    sleep_time = FAIL_SLEEP_TIME
     while True:
         if not is_connected_git_method():
             print('# network is down')
             start_wifi()
             kill_chromedriver()
+            sleep_time = FAIL_SLEEP_TIME
         else:
             print('# network is up')
-            pass
-        sleep(SLEEP_TIME)
+            sleep_time = SUCC_SLEEP_TIME
+        print('Sleeping for {duration}s.\n'.format(duration=sleep_time))
+        sleep(sleep_time)
  
 if __name__ == "__main__":
     main()

--- a/monitor.py
+++ b/monitor.py
@@ -7,6 +7,8 @@ import socket
 import urllib.request
 import urllib.error
 
+import subprocess
+
 PROCNAME = 'chromedriver'
 SLEEP_TIME = 10
  
@@ -14,6 +16,14 @@ def kill_chromedriver():
     for proc in psutil.process_iter():
         if proc.name == PROCNAME:
             proc.kill()
+
+def is_connected_git_method():
+  try:
+    result = subprocess.run(["ssh", "-T", "git@github.com", "-o ConnectTimeout=2"])
+    print(result.returncode)
+    return (result.returncode == 1)
+  except Exception as _:
+    return False
 
 def is_connected(host="8.8.8.8", port=53, timeout=3):
   """
@@ -35,7 +45,7 @@ def start_wifi():
  
 def main():
     while True:
-        if not is_connected():
+        if not is_connected_git_method():
             print('# network is down')
             start_wifi()
             kill_chromedriver()

--- a/monitor.py
+++ b/monitor.py
@@ -18,6 +18,8 @@ def kill_chromedriver():
             proc.kill()
 
 def is_connected_git_method():
+  # Note that you need to have a valid github key on your computer
+  # Even read-only deploy keys of one particular repo works
   try:
     result = subprocess.run(["ssh", "-T", "git@github.com", "-o ConnectTimeout=2"])
     print(result.returncode)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 splinter
 psutil
+selenium


### PR DESCRIPTION
This pull request address two major change in the login procedure:
1. New method for connection detection. As it seems 8.8.8.8 can be pinged before the actual login take place, the old function will fail. Now offering ssh-ing github as alternative. Do be careful not to ping Github too often.
2. The login page now force you to accept the terms in different pages, so the macro is updated to click that checkbox.

Miscs updates:
1. Previous pi setup instruction is unclear. Add remarks to sync the chrome version and driver version.
2. Selenium seems to be needed to run the code, so add that into requirements as well.